### PR TITLE
Fix packages with unpredictable pyqt 5.x restriction 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,7 @@
+ignore_version:
+  - python
+  - pyqt
+
 python:
   - 3.6
   - 3.7

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,4 @@
 ignore_version:
-  - python
   - pyqt
 
 python:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - {{ python }}
+    - python {{ python }}
   run:
     - eigen
     - fftw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - {{ python }}
   run:
     - eigen
     - fftw
@@ -29,7 +29,7 @@ requirements:
     - psutil
     - pyopengl
     - pyqt >=5.6
-    - python >=3.6
+    - {{ pin_compatible('python') }}
     - qtpy
     - sip
     - qimage2ndarray
@@ -37,7 +37,6 @@ requirements:
 test:
   requires:
     - pyqt {{ pyqt }}
-    - python {{ python }}
   imports:
     - gpi
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.1.2" %}
 {% set sha256 = "09e6c01c42c74489d3bb9a97b56614689c13a5d1b178ecfcc2c56c9192c75366" %}
-{% set build_num = "0" %}
+{% set build_num = "1" %}
 
 package:
   name: gpi
@@ -20,6 +20,7 @@ build:
 requirements:
   host:
     - python {{ python }}
+    - pyqt {{ pyqt }}
   run:
     - eigen
     - fftw
@@ -28,7 +29,7 @@ requirements:
     - pillow
     - psutil
     - pyopengl
-    - pyqt {{ pyqt }}
+    - {{ pin_compatible('pyqt') }}
     - {{ pin_compatible('python') }}
     - qtpy
     - sip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ build:
 requirements:
   host:
     - python {{ python }}
-    - pyqt {{ pyqt }}
   run:
     - eigen
     - fftw
@@ -29,13 +28,15 @@ requirements:
     - pillow
     - psutil
     - pyopengl
-    - {{ pin_compatible('pyqt') }}
+    - pyqt >=5.6
     - {{ pin_compatible('python') }}
     - qtpy
     - sip
     - qimage2ndarray
 
 test:
+  requires:
+    - pyqt {{ pyqt }}
   imports:
     - gpi
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - psutil
     - pyopengl
     - pyqt >=5.6
-    - python >=3.6}
+    - python >=3.6
     - qtpy
     - sip
     - qimage2ndarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python {{ python }}
+    - python >=3.6
   run:
     - eigen
     - fftw
@@ -29,7 +29,7 @@ requirements:
     - psutil
     - pyopengl
     - pyqt >=5.6
-    - {{ pin_compatible('python') }}
+    - python >=3.6}
     - qtpy
     - sip
     - qimage2ndarray
@@ -37,6 +37,7 @@ requirements:
 test:
   requires:
     - pyqt {{ pyqt }}
+    - python {{ python }}
   imports:
     - gpi
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The initial build only uploaded 4 packages after running 8 builds. The pyqt versions in the build matrix were ignored in naming the packages, so what was uploaded was arbitrarily pinned to pyqt 5.6 or 5.9 depending on which build finished last.

I think a fix for this is to move pyqt into the `host` section. However, this seems circuitous as the build doesn't really need pyqt (or python, for that matter).

@conda-forge/core — is there any way to specify pyqt >= 5.6 in the recipe while asking for tests to occur on both 5.6 and 5.9? I don't really need separate pyqt5.6 and pyqt5.9 packages to be created as they'll be identical anyway, but I do want to confirm that this works for both. Apologies if I missed this somewhere in the docs.