### PR TITLE
Fix build for gpi_make.cmd file inclusion

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,6 +28,7 @@ cp -R include/* $PREFIX/include/
 cp launch/gpi.command $PREFIX/bin/gpi
 # for Windows, indlude a batch script version
 cp launch/gpi_cmd.bat $PREFIX/bin/gpi.cmd
+cp launch/gpi_make.cmd $PREFIX/bin/gpi_make.cmd
 # (The shell should automatically pick up on the correct option)
 
 # copy licenses to lib dir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   skip_compile_pyc:
     - include/PyFI/*.py
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
